### PR TITLE
Bugfix/fix no click spa

### DIFF
--- a/src/main/collectors/CheckoutClickCollector.ts
+++ b/src/main/collectors/CheckoutClickCollector.ts
@@ -71,10 +71,16 @@ export class CheckoutClickCollector extends AbstractCollector {
 		// "sentinel (default)" - works on elements inserted in the DOM anytime, but interferes with CSS animations on these elements
 		if (this.listenerType === ListenerType.Dom) {
 			const nodeList = doc.querySelectorAll(this.clickSelector);
-			nodeList.forEach((el: HTMLElement) => el.addEventListener("click", this.logWrapHandler(handler, log)));
+			nodeList.forEach((el: HTMLElement) => el.addEventListener("click", this.logWrapHandler(handler, log), {
+				passive: true,
+				capture: true
+			}));
 		} else {
 			const sentinel = new Sentinel(this.getDocument());
-			sentinel.on(this.clickSelector, el => el.addEventListener("click", this.logWrapHandler(handler, log)));
+			sentinel.on(this.clickSelector, el => el.addEventListener("click", this.logWrapHandler(handler, log), {
+				passive: true,
+				capture: true
+			}));
 		}
 	}
 }

--- a/src/main/collectors/ClickCollector.ts
+++ b/src/main/collectors/ClickCollector.ts
@@ -61,10 +61,16 @@ export class ClickCollector extends AbstractCollector {
 		// "sentinel (default)" - works on elements inserted in the DOM anytime, but interferes with CSS animations on these elements
 		if (this.listenerType === ListenerType.Dom) {
 			const nodeList = this.getDocument().querySelectorAll(this.selectorExpression);
-			nodeList.forEach((el: HTMLElement) => el.addEventListener("click", this.logWrapHandler(handler, log, el)));
+			nodeList.forEach((el: HTMLElement) => el.addEventListener("click", this.logWrapHandler(handler, log, el), {
+				passive: true,
+				capture: true
+			}));
 		} else {
 			const sentinel = new Sentinel(this.getDocument());
-			sentinel.on(this.selectorExpression, el => el.addEventListener("click", this.logWrapHandler(handler, log, el)));
+			sentinel.on(this.selectorExpression, el => el.addEventListener("click", this.logWrapHandler(handler, log, el), {
+				passive: true,
+				capture: true
+			}));
 		}
 	}
 }

--- a/src/main/collectors/ClickWriterResolverCollector.ts
+++ b/src/main/collectors/ClickWriterResolverCollector.ts
@@ -31,10 +31,16 @@ export class ClickWriterResolverCollector extends WriterResolverCollector {
 
 		if (this.listenerType === ListenerType.Dom) {
 			const nodeList = this.getDocument().querySelectorAll(this.selectorExpression);
-			nodeList.forEach(el => el.addEventListener("click", ev => this.logWrapHandler(handler, log, el, ev)()));
+			nodeList.forEach(el => el.addEventListener("click", ev => this.logWrapHandler(handler, log, el, ev)(), {
+				passive: true,
+				capture: true
+			}));
 		} else {
 			const sentinel = new Sentinel(this.getDocument());
-			sentinel.on(this.selectorExpression, el => el.addEventListener("click", ev => this.logWrapHandler(handler, log, el, ev)()));
+			sentinel.on(this.selectorExpression, el => el.addEventListener("click", ev => this.logWrapHandler(handler, log, el, ev)(), {
+				passive: true,
+				capture: true
+			}));
 		}
 	}
 }

--- a/src/test/mock/__files/ProductClickCollector.page.html
+++ b/src/test/mock/__files/ProductClickCollector.page.html
@@ -6,6 +6,16 @@
     <script defer src="/dist/index.window.bundle.js"></script>
     <script>
 		document.addEventListener("DOMContentLoaded", () => {
+			const ele = document.querySelector("#innerClick");
+			ele.addEventListener("click", event => {
+				// VueJs is often adding listeners to the most inner element,
+				// if stopPropagation is called then our click listeners don't execute if they aren't added during capturing phase.
+				// I added a stopPropagation to simulate this, our listeners should still be executed in this test.
+				event.stopPropagation();
+			}, false);
+		});
+
+		document.addEventListener("DOMContentLoaded", () => {
 			const {
 				CollectorModule,
 				ProductClickCollector,
@@ -59,7 +69,9 @@
 <div class="product" data-id="2" data-price="2.99">Product</div>
 <div class="product" data-id="3" data-price="3.99">Product</div>
 <div class="product" data-id="4" data-price="4.99">Product</div>
-<div id="clickMe" class="product" data-id="5" data-price="5.99">Product</div>
+<div id="clickMe" class="product" data-id="5" data-price="5.99">
+    <div id="innerClick">Click Me Product</div>
+</div>
 <div class="product" data-id="6" data-price="6.99">Product</div>
 <div class="product" data-id="7" data-price="7.99">Product</div>
 <div class="product" data-id="8" data-price="8.99">Product</div>


### PR DESCRIPTION
VueJs is often adding listeners to the most inner element. If `stopPropagation` is called, our click listeners don't execute if they aren't added during the capturing phase.

I added a stopPropagation to the ProductClickCollector test to simulate this and added `capturing` to every `click` listener.