### PR TITLE
add optional expected page resolver to ImpressionsCollector

### DIFF
--- a/src/test/collectors/ImpressionCollector.test.ts
+++ b/src/test/collectors/ImpressionCollector.test.ts
@@ -49,4 +49,40 @@ describe('ImpressionCollectorTracking Suite', () => {
 			})
 			.verify();
 	});
+
+	test('track impression data with expected page false', async () => {
+		const stubAsserter = await createStubAsserter("ImpressionCollectorTracking_expected_false.json");
+
+		await page.goto(getHost() + "/ImpressionCollector.page.html?expectedPage=false", {waitUntil: 'load'});
+		await page.click("#scrollTarget");//click scrolls the element into view
+
+		await wait(750); //ImpressionCollector is debounced, give it some more time
+
+		await stubAsserter.verifyCallCount(0)
+			.verify();
+	});
+
+	test('track impression data with expected page true', async () => {
+		const stubAsserter = await createStubAsserter("ImpressionCollectorTracking_expected_true.json");
+
+		await page.goto(getHost() + "/ImpressionCollector.page.html?expectedPage=true", {waitUntil: 'load'});
+		await page.click("#scrollTarget");//click scrolls the element into view
+
+		await wait(750); //ImpressionCollector is debounced, give it some more time
+
+		await stubAsserter.verifyCallCount(1)
+			.verifyQueryParams(params => {
+				const event = JSON.parse(params.data.values[0]);
+				expect(event.type).toBe("impression");
+				expect(event.data.length).toBe(10)
+
+				event.data.forEach(impression => {
+					expect(impression.position).toBeDefined();
+					expect(typeof impression.position).toBe("number");
+					expect(impression.id).toBeDefined();
+					expect(typeof impression.id).toBe("string");
+				});
+			})
+			.verify();
+	});
 });

--- a/src/test/mock/__files/ImpressionCollector.page.html
+++ b/src/test/mock/__files/ImpressionCollector.page.html
@@ -17,10 +17,22 @@
 				writer: new RestEventWriter(location.origin + "/impression-collector-channel")
 			});
 
-			collector.add(
-				new ImpressionCollector(".product",
-					element => element.getAttribute("data-id"),
-					element => positionResolver(".product", element)));
+
+			const params = new URLSearchParams(window.location.search);
+
+			if (!params.has("expectedPage")) {
+				collector.add(
+					new ImpressionCollector(".product",
+						element => element.getAttribute("data-id"),
+						element => positionResolver(".product", element)));
+			} else {
+				collector.add(
+					new ImpressionCollector(".product",
+						element => element.getAttribute("data-id"),
+						element => positionResolver(".product", element),
+						element => params.get("expectedPage") === "true"));
+			}
+
 
 			collector.start();
 		});

--- a/src/test/mock/api-stubs/ImpressionCollectorTracking_expected_false.json
+++ b/src/test/mock/api-stubs/ImpressionCollectorTracking_expected_false.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/impression-collector-channel",
+    "queryParameters": {
+      "data": {
+        "contains": "impression"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "OK",
+    "headers": {
+      "Content-Type": "text/plain"
+    }
+  }
+}

--- a/src/test/mock/api-stubs/ImpressionCollectorTracking_expected_true.json
+++ b/src/test/mock/api-stubs/ImpressionCollectorTracking_expected_true.json
@@ -1,0 +1,18 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/impression-collector-channel",
+    "queryParameters": {
+      "data": {
+        "contains": "impression"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": "OK",
+    "headers": {
+      "Content-Type": "text/plain"
+    }
+  }
+}


### PR DESCRIPTION
Single page applications require an expected resolver for impressions, otherwise a lot of unnecessary errors are produced because the ImpressionsCollector remains on the SPA and triggers for non search related products. 