### PR TITLE
only track redirect if we come from the same origin

### DIFF
--- a/src/main/collectors/RedirectCollector.ts
+++ b/src/main/collectors/RedirectCollector.ts
@@ -45,19 +45,37 @@ export class RedirectCollector extends AbstractCollector {
 			// Remove the search action, as we're either on a search result page or we've redirected
 			getSessionStorage().removeItem(RedirectCollector.STORAGE_KEY);
 
-			// If we have not landed on the expected search page, it must have been (looove) a redirect
-			if (!this.resolve(this.expectedPageResolver, log)) {
-				// Thus record the redirect
-				const query = new Query();
-				query.setSearch(lastSearch);
+			if (shouldTrackRedirect(document.referrer)) {
+				// If we have not landed on the expected search page, it must have been (looove) a redirect
+				if (!this.resolve(this.expectedPageResolver, log)) {
+					// Thus record the redirect
+					const query = new Query();
+					query.setSearch(lastSearch);
 
-				writer.write({
-					type: "redirect",
-					keywords: lastSearch,
-					query: query.toString(),
-					url: window.location.href
-				});
+					writer.write({
+						type: "redirect",
+						keywords: lastSearch,
+						query: query.toString(),
+						url: window.location.href
+					});
+				}
 			}
 		}
 	}
+}
+
+
+function shouldTrackRedirect(referer: string) {
+	if (referer) {
+		try {
+			const refUrl = new URL(referer);
+			const currentUrl = new URL(window.location.href);
+			if (currentUrl.origin && refUrl.origin)
+				return refUrl.origin === currentUrl.origin;
+		} catch (e) {
+			console.error(e);
+		}
+	}
+
+	return true;
 }

--- a/src/test/mock/__files/RedirectCollector.page.html
+++ b/src/test/mock/__files/RedirectCollector.page.html
@@ -20,17 +20,27 @@
 				document.querySelector("#searchButton").addEventListener("mouseup", () => {
 					callback(document.querySelector("#searchInput").value);
 				});
+
+				document.querySelector("#triggerFiredSearchButton").addEventListener("mouseup", () => {
+					callback(document.querySelector("#searchInput").value);
+				});
 			}
 
 			collector.add(new RedirectCollector(firedSearchCallback, () => {
 				const params = new URLSearchParams(window.location.search);
-				return params.get("isSearchPage") !== "false";
+				return params.get("isSearchPage") === "true";
 			}));
 
 			document.querySelector("#searchButton").addEventListener("click", () => {
 				const params = new URLSearchParams(document.location.search);
+				params.delete("isSearchPage");
 				params.append("isSearchPage", "false");
 				document.location.href = document.location.origin + window.location.pathname + "?" + params.toString();
+			});
+
+			Object.defineProperty(document, 'referer', {
+				value: "https://www.google.dom",
+				writable: false
 			});
 
 			collector.start();
@@ -44,6 +54,8 @@
 <!--search box-->
 <input id="searchInput" value="THE REDIRECT QUERY"/>
 <button id="searchButton">search button</button>
+<button id="triggerFiredSearchButton">fired search button</button>
+
 
 <!--10-->
 <div class="product"></div>


### PR DESCRIPTION
We discovered strange sessions with wrong redirect events. 
We were able to reproduce it like following:
_Search with google -> Click a link of the onlineshop -> trigger a search and immediately hit the back button, it is important the new search page didn't load -> click another link of the same onlineshop -> redirect is tracked._ 
Duo to the fact that a triggered search event is fired but the shop never loaded the search page the collector expects to land on PLP but he doesn't. 

Therefore we check for the referrer property. If it is not the same origin as the current, we discard the redirect event.