### PR TITLE
fix no query on basket click after redirect + fix collectors not atta…

### DIFF
--- a/src/main/collectors/RedirectCollector.ts
+++ b/src/main/collectors/RedirectCollector.ts
@@ -1,13 +1,19 @@
 import {AbstractCollector} from "./AbstractCollector";
 import {Context} from "../utils/Context";
-import {BooleanResolver, CallbackResolver, NumberResolver, QueryResolver} from "../resolvers/Resolver";
+import {
+	BooleanResolver,
+	CallbackResolver,
+	cookieSessionResolver,
+	NumberResolver,
+	StringResolver
+} from "../resolvers/Resolver";
 import {getSessionStorage} from "../utils";
-import {Query} from "../query";
+import {Query, Trail, TrailType} from "../query";
 
-type RedirectKpiCollectorParams = {
+export type RedirectKpiCollectorParams = {
 	resultCountResolver?: NumberResolver
 	collectors?: Array<AbstractCollector>,
-	queryResolver?: QueryResolver,
+	redirectTTLMillis?: number
 }
 
 /**
@@ -16,10 +22,19 @@ type RedirectKpiCollectorParams = {
 export class RedirectCollector extends AbstractCollector {
 
 	private static STORAGE_KEY = "__lastSearch";
+	private static PATH_STORAGE_KEY = "___pathStorage";
 
 	private readonly resultCountResolver: NumberResolver;
 	private readonly collectors: Array<AbstractCollector>;
-	private readonly queryResolver: QueryResolver | ((phrase) => Query);
+	private readonly queryResolver: (phrase) => Query;
+	private readonly sessionResolver: StringResolver;
+	private readonly redirectTTL: number;
+	private readonly redirectTrail: Trail;
+
+	/**
+	 * Used to track if the trigger has been installed already in case attached is called multiple times
+	 */
+	private isTriggerInstalled = false;
 
 	/**
 	 * Construct redirect collector
@@ -40,16 +55,74 @@ export class RedirectCollector extends AbstractCollector {
 
 		this.collectors = redirectKpiParams.collectors || [];
 		this.resultCountResolver = redirectKpiParams.resultCountResolver || (_ => void 0);
-		this.queryResolver = redirectKpiParams.queryResolver || ((phrase) => {
+		this.redirectTTL = this.redirectKpiParams.redirectTTLMillis || 86400000;
+
+		this.queryResolver = (phrase) => {
 			const query = new Query();
 			query.setSearch(phrase);
 			return query;
-		});
+		};
+
+		this.sessionResolver = () => cookieSessionResolver();
+
+		this.redirectTrail = new Trail(() => {
+			const pathInfo = RedirectCollector.getRedirectPathInfo(window.location.pathname);
+			return new Query(pathInfo?.query);
+		}, this.sessionResolver);
 	}
 
 	public setContext(context: Context) {
 		super.setContext(context);
 		this.collectors.forEach(collector => collector.setContext(context));
+	}
+
+	/**
+	 * Marks this path as a redirect landing page.
+	 * @param path the pathname e.g. /some-path
+	 * @param query the query which lead to this path
+	 * @private
+	 */
+	private static setRedirectPath(path: string, query: string) {
+		const redirectPaths = this.getRedirectPaths();
+		redirectPaths[path] = {
+			query,
+			timestamp: new Date().getTime()
+		};
+
+		getSessionStorage().setItem(RedirectCollector.PATH_STORAGE_KEY, JSON.stringify(redirectPaths));
+	}
+
+	/**
+	 * Get all marked paths
+	 * @private
+	 */
+	private static getRedirectPaths() {
+		return JSON.parse(getSessionStorage().getItem(RedirectCollector.PATH_STORAGE_KEY) || "{}");
+	}
+
+	/**
+	 * Retrieve data for the given path
+	 * @param path
+	 * @private
+	 */
+	private static getRedirectPathInfo(path: string) {
+		return this.getRedirectPaths()[path];
+	}
+
+	/**
+	 * Delete all expired redirect paths
+	 * @private
+	 */
+	private expireRedirectPaths() {
+		const redirectPaths = RedirectCollector.getRedirectPaths();
+		const now = new Date().getTime();
+		Object.keys(redirectPaths).forEach(path => {
+			const pathInfo = redirectPaths[path];
+			if (now - Number(pathInfo.timestamp) > this.redirectTTL) {
+				delete redirectPaths[path];
+			}
+		});
+		getSessionStorage().setItem(RedirectCollector.PATH_STORAGE_KEY, JSON.stringify(redirectPaths));
 	}
 
 	/**
@@ -59,39 +132,60 @@ export class RedirectCollector extends AbstractCollector {
 	 * @param log
 	 */
 	attach(writer, log) {
-		this.resolve(this.triggerResolver, log, keyword => {
-			getSessionStorage().setItem(RedirectCollector.STORAGE_KEY, keyword);
-		});
+		if (this.isTriggerInstalled === false) {
+			this.resolve(this.triggerResolver, log, keyword => getSessionStorage().setItem(RedirectCollector.STORAGE_KEY, keyword));
+			this.isTriggerInstalled = true;
+		}
+
+		this.expireRedirectPaths();
 
 		// Fetch the latest search if any
 		const lastSearch = getSessionStorage().getItem(RedirectCollector.STORAGE_KEY);
+
 		if (lastSearch) {
-			// Remove the search action, as we're either on a search result page or we've redirected
 			getSessionStorage().removeItem(RedirectCollector.STORAGE_KEY);
 
-			if (shouldTrackRedirect(document.referrer)) {
-				// If we have not landed on the expected search page, it must have been (looove) a redirect
-				if (!this.resolve(this.expectedPageResolver, log)) {
-					// Thus record the redirect
-					const query = this.queryResolver(lastSearch)
+			// If we have not landed on the expected search page, it must have been a redirect
+			if (shouldTrackRedirect(document.referrer) && !this.resolve(this.expectedPageResolver, log)) {
+				const query = this.queryResolver(lastSearch).toString()
+				writer.write({
+					type: "redirect",
+					keywords: lastSearch,
+					query,
+					url: window.location.href,
+					resultCount: this.resolve(this.resultCountResolver, log)
+				});
 
-					writer.write({
-						type: "redirect",
-						keywords: lastSearch,
-						query: query.toString(),
-						url: window.location.href,
-						resultCount: this.resolve(this.resultCountResolver, log)
-					});
-
-					// attach all collectors which are responsible to gather kpi's after the redirect
-					this.collectors.forEach(collector => collector.attach({
-						write(data) {
-							writer.write({...data, query: query.toString()});
-						}
-					}, log));
-				}
+				// mark as redirect landing page
+				RedirectCollector.setRedirectPath(window.location.pathname, query);
+				// register a trail with the pathname for subsequent click events. See ProductClickCollector.ts
+				this.redirectTrail.register(window.location.pathname, TrailType.Main, query);
 			}
 		}
+
+		/**
+		 * Check if we have tracked this path before and if it is still valid.
+		 * If valid, we have to attach the KPI collectors to gather KPIs for this landing page.
+		 * We have to do this because people can navigate away from the landing page and back again and we don't want to lose all subsequent clicks etc.
+		 */
+		const pathInfo = RedirectCollector.getRedirectPathInfo(this.getWindow().location.pathname);
+		if (pathInfo)
+			this.attachCollectors(writer, log, pathInfo.query);
+	}
+
+	private attachCollectors(writer, log, query) {
+		// attach all collectors which are responsible to gather kpi's after the redirect
+		this.collectors.forEach(collector => {
+			try {
+				collector.attach({
+					write(data) {
+						writer.write({...data, query});
+					}
+				}, log)
+			} catch (e) {
+				log.error(e);
+			}
+		});
 	}
 }
 

--- a/src/test/collectors/ProductClickCollector.test.ts
+++ b/src/test/collectors/ProductClickCollector.test.ts
@@ -65,4 +65,32 @@ describe('ProductClickCollector Suite', () => {
 			})
 			.verify();
 	});
+
+	test('track product click data with existing path trail', async () => {
+		const asserter = await createStubAsserter("ProductClickCollectorTracking.json");
+
+		await page.goto(getHost() + "/ProductClickCollector.page.html?collector=all&useTrailQuery=customQuery", {waitUntil: 'networkidle0'});
+		await page.click("#clickMe");
+		await wait(100);
+
+		// make sure a trail for that path exists
+		const trail = await page.evaluate(() => {
+			return localStorage.getItem("search-collector-trail");
+		});
+		const pathInfo = JSON.parse(trail)["/ProductClickCollector.page.html"];
+		expect(pathInfo.query).toBe("$s=customQuery/");
+
+		await asserter.verifyCallCount(1)
+			.verifyQueryParams(params => {
+				const trackingData = JSON.parse(params.data.values[0]);
+				expect(trackingData.type).toBe("product");
+				expect(trackingData.id).toBe("5");
+				expect(trackingData.position).toBe(4);
+				expect(trackingData.price).toBe(5.99);
+				expect(trackingData.image).toBe("image.jpg");
+				expect(trackingData.query).toBe("$s=customQuery/");
+				expect(trackingData.metadata).toBe("DIV");
+			})
+			.verify();
+	});
 });

--- a/src/test/collectors/RedirectCollector.test.ts
+++ b/src/test/collectors/RedirectCollector.test.ts
@@ -64,6 +64,13 @@ describe('RedirectCollector Suite', () => {
 
 		await wait(100);
 
+		// make sure a trail for that path exists
+		const trail = await page.evaluate(() => {
+			return localStorage.getItem("search-collector-trail");
+		});
+		const pathInfo = JSON.parse(trail)["/RedirectCollectorWithProductClicks.page.html"];
+		expect(pathInfo.query).toBe("$s=THE REDIRECT QUERY/");
+
 		await redirectStubAsserter.verifyCallCount(1)
 			.verifyQueryParams(params => {
 				const trackingData = JSON.parse(params.data.values[0]);

--- a/src/test/mock/__files/ProductClickCollector.page.html
+++ b/src/test/mock/__files/ProductClickCollector.page.html
@@ -21,7 +21,23 @@
 				ProductClickCollector,
 				RestEventWriter,
 				positionResolver,
+				Trail,
+				TrailType,
+				Query
 			} = window.SearchCollector;
+
+			const params = new URLSearchParams(window.location.search);
+			const trail = new Trail(() => {
+				const q = new Query();
+				q.setSearch("THE QUERY");
+				return q;
+			}, () => "session1234");
+
+			if (params.has("useTrailQuery")) {
+				const q = new Query();
+				q.setSearch(params.get("useTrailQuery"))
+				trail.register(window.location.pathname, TrailType.Main, q.toString());
+			}
 
 			const collector = new CollectorModule({
 				writer: new RestEventWriter(location.origin + "/product-click-collector-channel")
@@ -29,7 +45,8 @@
 
 			if (new URLSearchParams(window.location.search).get("collector") === "none") {
 				collector.add(new ProductClickCollector(".product", {
-					idResolver: element => element.getAttribute("data-id")
+					idResolver: element => element.getAttribute("data-id"),
+					trail
 				}));
 			} else {
 				collector.add(new ProductClickCollector(".product", {
@@ -37,7 +54,8 @@
 					positionResolver: element => positionResolver(".product", element),
 					priceResolver: element => Number(element.getAttribute("data-price")),
 					imageResolver: element => "image.jpg",
-					metadataResolver: element => element.nodeName
+					metadataResolver: element => element.nodeName,
+					trail
 				}));
 			}
 


### PR DESCRIPTION
* fix no query on basket click after redirect 
* fix redirect collectors not attached after navigation forth and back again

Some info:
RedirectCollector registers a Trail after a redirect with the window.location.pathname as id containing the query which triggered the redirect. 
ProductClickCollector does now pick up the Trail for the current path registered by RedirectCollector. If a trail exists, the query is overridden by the one from the Trail/RedirectCollector. 

This way we can track the all events with the correct query.
trigger search -> redirect happens (a redirect query gets registered)  -> click on a product on the landing page(click collector now uses the query from the Trail/Redirect)  -> PDP add to basket and checkout are now using the correct query (the one which triggered the redirect)

In addition landing pages are marked as redirect landing pages, this way we are able to track pagination and _"forth and back click"_ scenarios and collect the KPIs for properly for the redirected query